### PR TITLE
Add Products module with Excel import/export

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { UserModule } from './modules/user/user.module';
 import { TradeModule } from './modules/trade/trade.module';
 import { FileModule } from './modules/file/file.module';
 import { CustomerModule } from './modules/customer/customer.module';
+import { ProductModule } from "./modules/product/product.module";
 import { DatabaseModule } from './database/database.module';
 import { SharedModule } from './shared/shared.module';
 import { AuthMiddleware } from './auth/middleware/auth.middleware';
@@ -44,6 +45,7 @@ import configuration from './config/configuration';
     TradeModule,
     FileModule,
     CustomerModule,
+    ProductModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/product/dto/create-product.dto.ts
+++ b/src/modules/product/dto/create-product.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsNumber,
+  Min,
+  Max,
+} from 'class-validator';
+import { ProductType, ProductStatus } from '../entities/product.entity';
+import { RiskLevel } from '../../customer/entities/customer.entity';
+
+export class CreateProductDto {
+  @ApiProperty({ description: '产品名称', example: '稳健理财产品' })
+  @IsString({ message: '产品名称必须是字符串' })
+  @IsNotEmpty({ message: '产品名称不能为空' })
+  productName: string;
+
+  @ApiProperty({ description: '产品类型', enum: ProductType })
+  @IsEnum(ProductType, { message: '请选择有效的产品类型' })
+  productType: ProductType;
+
+  @ApiProperty({ description: '产品描述', required: false })
+  @IsString({ message: '产品描述必须是字符串' })
+  @IsOptional()
+  description?: string;
+
+  @ApiProperty({ description: '风险等级', enum: RiskLevel })
+  @IsEnum(RiskLevel, { message: '请选择有效的风险等级' })
+  riskLevel: RiskLevel;
+
+  @ApiProperty({ description: '最低投资金额', example: 1000 })
+  @IsNumber({}, { message: '最低投资金额必须是数字' })
+  @Min(0)
+  minInvestment: number;
+
+  @ApiProperty({ description: '最高投资金额', example: 100000 })
+  @IsNumber({}, { message: '最高投资金额必须是数字' })
+  @Min(0)
+  maxInvestment: number;
+
+  @ApiProperty({ description: '预期年化收益率(%)', example: 5 })
+  @IsNumber({}, { message: '预期收益率必须是数字' })
+  expectedReturn: number;
+
+  @ApiProperty({ description: '结息日期', example: '每月' })
+  @IsString()
+  interestPaymentDate: string;
+
+  @ApiProperty({ description: '产品期限(天)', example: 365 })
+  @IsNumber({}, { message: '产品期限必须是数字' })
+  @Min(0)
+  maturityPeriod: number;
+
+  @ApiProperty({ description: '产品状态', enum: ProductStatus, required: false })
+  @IsEnum(ProductStatus, { message: '请选择有效的产品状态' })
+  @IsOptional()
+  status?: ProductStatus = ProductStatus.ACTIVE;
+
+  @ApiProperty({ description: '销售开始日期', example: '2024-01-01' })
+  @IsString()
+  salesStartDate: string;
+
+  @ApiProperty({ description: '销售结束日期', example: '2024-12-31' })
+  @IsString()
+  salesEndDate: string;
+}

--- a/src/modules/product/dto/import-result.dto.ts
+++ b/src/modules/product/dto/import-result.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ImportErrorDetail {
+  @ApiProperty({
+    description: '行号',
+    example: 2,
+  })
+  row: number;
+
+  @ApiProperty({
+    description: '错误信息',
+    example: '邮箱格式不正确',
+  })
+  error: string;
+
+  @ApiProperty({
+    description: '客户数据',
+    example: {
+      email: 'invalid-email',
+      phone: '+86 138 0013 8000',
+      firstName: '小明',
+      lastName: '张',
+    },
+  })
+  data: any;
+}
+
+export class ImportResultDto {
+  @ApiProperty({
+    description: '导入成功数量',
+    example: 10,
+  })
+  successCount: number;
+
+  @ApiProperty({
+    description: '导入失败数量',
+    example: 2,
+  })
+  failureCount: number;
+
+  @ApiProperty({
+    description: '跳过数量（重复数据）',
+    example: 1,
+  })
+  skippedCount: number;
+
+  @ApiProperty({
+    description: '总处理数量',
+    example: 13,
+  })
+  totalCount: number;
+
+  @ApiProperty({
+    description: '错误详情列表',
+    type: [ImportErrorDetail],
+  })
+  errors: ImportErrorDetail[];
+
+  @ApiProperty({
+    description: '导入结果消息',
+    example: '导入完成：成功 10 条，失败 2 条，跳过 1 条',
+  })
+  message: string;
+}

--- a/src/modules/product/dto/query-product.dto.ts
+++ b/src/modules/product/dto/query-product.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsEnum, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ProductType, ProductStatus } from '../entities/product.entity';
+
+export class QueryProductDto {
+  @ApiProperty({ description: '页码', example: 1, required: false, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ description: '每页数量', example: 10, required: false, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @ApiProperty({ description: '搜索关键词(产品名称)', required: false })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({ description: '产品类型筛选', enum: ProductType, required: false })
+  @IsOptional()
+  @IsEnum(ProductType)
+  productType?: ProductType;
+
+  @ApiProperty({ description: '产品状态筛选', enum: ProductStatus, required: false })
+  @IsOptional()
+  @IsEnum(ProductStatus)
+  status?: ProductStatus;
+
+  @ApiProperty({ description: '排序字段', required: false, enum: ['createdAt', 'updatedAt', 'productName'] })
+  @IsOptional()
+  @IsString()
+  sortBy?: string = 'createdAt';
+
+  @ApiProperty({ description: '排序方向', required: false, enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}
+
+export class ProductListResponse {
+  @ApiProperty({ description: '产品列表', type: 'array' })
+  data: any[];
+
+  @ApiProperty({ description: '总数量', example: 100 })
+  total: number;
+
+  @ApiProperty({ description: '当前页码', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: '每页数量', example: 10 })
+  limit: number;
+
+  @ApiProperty({ description: '总页数', example: 10 })
+  totalPages: number;
+}

--- a/src/modules/product/dto/update-product.dto.ts
+++ b/src/modules/product/dto/update-product.dto.ts
@@ -1,0 +1,12 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+import { CreateProductDto } from './create-product.dto';
+
+export class UpdateProductDto extends PartialType(CreateProductDto) {
+  @ApiProperty({ description: '产品ID', required: false })
+  @IsString()
+  @IsOptional()
+  productId?: string;
+}

--- a/src/modules/product/entities/product.entity.ts
+++ b/src/modules/product/entities/product.entity.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RiskLevel } from '../../customer/entities/customer.entity';
+
+export enum ProductStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  SUSPENDED = 'suspended',
+}
+
+export enum ProductType {
+  WEALTH = '理财',
+  FUND = '基金',
+  BOND = '债券',
+  INSURANCE = '保险',
+}
+
+export class Product {
+  @ApiProperty({ description: '产品ID', example: 'prod_123456' })
+  productId: string;
+
+  @ApiProperty({ description: '产品名称', example: '稳健理财产品' })
+  productName: string;
+
+  @ApiProperty({
+    description: '产品类型',
+    enum: ProductType,
+    example: ProductType.WEALTH,
+  })
+  productType: ProductType;
+
+  @ApiProperty({ description: '产品描述', required: false })
+  description?: string;
+
+  @ApiProperty({
+    description: '风险等级',
+    enum: RiskLevel,
+    example: RiskLevel.MEDIUM,
+  })
+  riskLevel: RiskLevel;
+
+  @ApiProperty({ description: '最低投资金额', example: 1000 })
+  minInvestment: number;
+
+  @ApiProperty({ description: '最高投资金额', example: 100000 })
+  maxInvestment: number;
+
+  @ApiProperty({ description: '预期年化收益率(%)', example: 5 })
+  expectedReturn: number;
+
+  @ApiProperty({ description: '结息日期', example: '每月' })
+  interestPaymentDate: string;
+
+  @ApiProperty({ description: '产品期限(天)', example: 365 })
+  maturityPeriod: number;
+
+  @ApiProperty({
+    description: '产品状态',
+    enum: ProductStatus,
+    example: ProductStatus.ACTIVE,
+  })
+  status: ProductStatus;
+
+  @ApiProperty({ description: '销售开始日期', example: '2024-01-01' })
+  salesStartDate: string;
+
+  @ApiProperty({ description: '销售结束日期', example: '2024-12-31' })
+  salesEndDate: string;
+
+  @ApiProperty({ description: '创建时间', example: '2024-01-01T00:00:00.000Z' })
+  createdAt: string;
+
+  @ApiProperty({ description: '更新时间', example: '2024-01-01T00:00:00.000Z' })
+  updatedAt: string;
+}

--- a/src/modules/product/product.controller.ts
+++ b/src/modules/product/product.controller.ts
@@ -1,0 +1,110 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Put,
+  Param,
+  Delete,
+  Query,
+  Res,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Response } from 'express';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiConsumes,
+} from '@nestjs/swagger';
+
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles, Role } from '../../common/decorators/roles.decorator';
+
+import { ProductService } from './product.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { QueryProductDto, ProductListResponse } from './dto/query-product.dto';
+import { ImportResultDto } from './dto/import-result.dto';
+import { Product } from './entities/product.entity';
+
+@ApiTags('Products')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(RolesGuard)
+@Controller('products')
+export class ProductController {
+  constructor(private readonly productService: ProductService) {}
+
+  @Post()
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: '创建产品' })
+  create(@Body() dto: CreateProductDto): Promise<Product> {
+    return this.productService.create(dto);
+  }
+
+  @Get()
+  @Roles(Role.ADMIN, Role.USER)
+  @ApiOperation({ summary: '获取产品列表' })
+  @ApiQuery({ name: 'page', required: false })
+  findAll(@Query() query: QueryProductDto): Promise<ProductListResponse> {
+    return this.productService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(Role.ADMIN, Role.USER)
+  @ApiOperation({ summary: '获取产品详情' })
+  @ApiParam({ name: 'id', description: '产品ID' })
+  findOne(@Param('id') id: string): Promise<Product> {
+    return this.productService.findOne(id);
+  }
+
+  @Put(':id')
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: '更新产品' })
+  @ApiParam({ name: 'id', description: '产品ID' })
+  update(@Param('id') id: string, @Body() dto: UpdateProductDto): Promise<Product> {
+    return this.productService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: '删除产品' })
+  @ApiParam({ name: 'id', description: '产品ID' })
+  remove(@Param('id') id: string) {
+    return this.productService.remove(id);
+  }
+
+  @Get('export')
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: '导出产品数据为Excel' })
+  async export(@Res() res: Response) {
+    const products = await this.productService.getAllForExport();
+    const buf = await this.productService.generateExcelBuffer(products);
+    const filename = `products_${new Date().toISOString().split('T')[0]}.xlsx`;
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Content-Length', buf.length);
+    res.send(buf);
+  }
+
+  @Post('import')
+  @Roles(Role.ADMIN)
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiOperation({ summary: '从Excel导入产品数据' })
+  async import(
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<ImportResultDto> {
+    if (!file) throw new BadRequestException('请选择要上传的Excel文件');
+    return this.productService.importFromExcel(file);
+  }
+}

--- a/src/modules/product/product.module.ts
+++ b/src/modules/product/product.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { ProductService } from './product.service';
+import { ProductController } from './product.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [ProductService],
+  controllers: [ProductController],
+  exports: [ProductService],
+})
+export class ProductModule {}

--- a/src/modules/product/product.service.ts
+++ b/src/modules/product/product.service.ts
@@ -1,0 +1,204 @@
+import {
+  Injectable,
+
+  NotFoundException,
+  BadRequestException,
+  Logger,
+  UnsupportedMediaTypeException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { v4 as uuidv4 } from 'uuid';
+import * as Excel from 'exceljs';
+
+import { DynamodbService } from '../../database/dynamodb.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { QueryProductDto, ProductListResponse } from './dto/query-product.dto';
+import { Product, ProductStatus, ProductType } from './entities/product.entity';
+import { ImportResultDto, ImportErrorDetail } from './dto/import-result.dto';
+
+@Injectable()
+export class ProductService {
+  private readonly logger = new Logger(ProductService.name);
+  private readonly tableName: string;
+
+  constructor(
+    private readonly dynamodbService: DynamodbService,
+    private readonly configService: ConfigService,
+  ) {
+    this.tableName = this.configService.get<string>('database.tables.products');
+  }
+
+  async create(createDto: CreateProductDto): Promise<Product> {
+    const now = new Date().toISOString();
+    const productId = `prod_${uuidv4()}`;
+
+    const product: Product = {
+      productId,
+      ...createDto,
+      status: createDto.status || ProductStatus.ACTIVE,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.dynamodbService.put(this.tableName, product);
+    return product;
+  }
+
+  async findAll(query: QueryProductDto): Promise<ProductListResponse> {
+    const all = await this.dynamodbService.scan(this.tableName);
+
+    let items = all;
+    if (query.search) {
+      const term = query.search.toLowerCase();
+      items = items.filter((p) => p.productName.toLowerCase().includes(term));
+    }
+    if (query.productType) {
+      items = items.filter((p) => p.productType === query.productType);
+    }
+    if (query.status) {
+      items = items.filter((p) => p.status === query.status);
+    }
+
+    items.sort((a, b) => {
+      const aVal = a[query.sortBy] || '';
+      const bVal = b[query.sortBy] || '';
+      if (query.sortOrder === 'asc') return String(aVal).localeCompare(String(bVal));
+      return String(bVal).localeCompare(String(aVal));
+    });
+
+    const total = items.length;
+    const totalPages = Math.ceil(total / query.limit);
+    const start = (query.page - 1) * query.limit;
+    const end = start + query.limit;
+    const data = items.slice(start, end);
+
+    return { data, total, page: query.page, limit: query.limit, totalPages };
+  }
+
+  async findOne(productId: string): Promise<Product> {
+    const product = await this.dynamodbService.get(this.tableName, { productId });
+    if (!product) throw new NotFoundException('产品不存在');
+    return product;
+  }
+
+  async update(productId: string, updateDto: UpdateProductDto): Promise<Product> {
+    await this.findOne(productId);
+
+    if (updateDto.productId && updateDto.productId !== productId) {
+      throw new BadRequestException('产品ID与参数不一致');
+    }
+
+    let updateExpression = 'SET #updatedAt = :updatedAt';
+    const names: Record<string, string> = { '#updatedAt': 'updatedAt' };
+    const values: Record<string, any> = { ':updatedAt': new Date().toISOString() };
+
+    Object.keys(updateDto).forEach((key, i) => {
+      const attr = `#attr${i}`;
+      const val = `:val${i}`;
+      updateExpression += `, ${attr} = ${val}`;
+      names[attr] = key;
+      values[val] = (updateDto as any)[key];
+    });
+
+    const updated = await this.dynamodbService.update(
+      this.tableName,
+      { productId },
+      updateExpression,
+      values,
+      names,
+    );
+
+    return updated;
+  }
+
+  async remove(productId: string): Promise<{ message: string }> {
+    await this.findOne(productId);
+    await this.dynamodbService.delete(this.tableName, { productId });
+    return { message: '产品删除成功' };
+  }
+
+  async getAllForExport(): Promise<Product[]> {
+    const items = await this.dynamodbService.scan(this.tableName);
+    items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    return items;
+  }
+
+  async generateExcelBuffer(products: Product[]): Promise<Buffer> {
+    const workbook = new Excel.Workbook();
+    const sheet = workbook.addWorksheet('产品数据');
+
+    sheet.columns = [
+      { header: '产品ID', key: 'productId', width: 20 },
+      { header: '产品名称', key: 'productName', width: 20 },
+      { header: '产品类型', key: 'productType', width: 15 },
+      { header: '风险等级', key: 'riskLevel', width: 10 },
+      { header: '最低投资金额', key: 'minInvestment', width: 15 },
+      { header: '最高投资金额', key: 'maxInvestment', width: 15 },
+      { header: '预期收益率', key: 'expectedReturn', width: 15 },
+      { header: '结息日期', key: 'interestPaymentDate', width: 15 },
+      { header: '产品期限', key: 'maturityPeriod', width: 12 },
+      { header: '产品状态', key: 'status', width: 12 },
+      { header: '销售开始日期', key: 'salesStartDate', width: 15 },
+      { header: '销售结束日期', key: 'salesEndDate', width: 15 },
+      { header: '创建时间', key: 'createdAt', width: 20 },
+    ];
+
+    products.forEach((p) => sheet.addRow(p));
+
+    return workbook.xlsx.writeBuffer();
+  }
+
+  async importFromExcel(file: Express.Multer.File): Promise<ImportResultDto> {
+    if (!file.originalname.endsWith('.xlsx')) {
+      throw new UnsupportedMediaTypeException('仅支持xlsx格式');
+    }
+
+    const workbook = new Excel.Workbook();
+    await workbook.xlsx.load(file.buffer);
+    const worksheet = workbook.worksheets[0];
+
+    const rows: any[] = [];
+    worksheet.eachRow((row, rowNumber) => {
+      if (rowNumber === 1) return;
+      const data = {
+        productName: row.getCell(1).text.trim(),
+        productType: row.getCell(2).text.trim() as ProductType,
+        riskLevel: row.getCell(3).text.trim() as any,
+        minInvestment: Number(row.getCell(4).value),
+        maxInvestment: Number(row.getCell(5).value),
+        expectedReturn: Number(row.getCell(6).value),
+        interestPaymentDate: row.getCell(7).text.trim(),
+        maturityPeriod: Number(row.getCell(8).value),
+        status: (row.getCell(9).text.trim() as ProductStatus) || ProductStatus.ACTIVE,
+        salesStartDate: row.getCell(10).text.trim(),
+        salesEndDate: row.getCell(11).text.trim(),
+        description: row.getCell(12).text.trim(),
+      } as any;
+      rows.push({ data, rowNumber });
+    });
+
+    let successCount = 0;
+    const errors: ImportErrorDetail[] = [];
+
+    for (const item of rows) {
+      try {
+        await this.create(item.data);
+        successCount++;
+      } catch (e) {
+        errors.push({ row: item.rowNumber, error: e.message, data: item.data });
+      }
+    }
+
+    const result: ImportResultDto = {
+      successCount,
+      failureCount: errors.length,
+      skippedCount: 0,
+      totalCount: rows.length,
+      errors,
+      message: `导入完成：成功 ${successCount} 条，失败 ${errors.length} 条`,
+    };
+
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- add Product entity and DTOs
- implement Product service with DynamoDB CRUD and Excel import/export
- create Product controller
- register ProductModule in AppModule
- add optional `productId` field for updating products and validate it

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_687715b495dc8326b709dcc81518e6cc