### PR TITLE
Add transaction module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { TradeModule } from './modules/trade/trade.module';
 import { FileModule } from './modules/file/file.module';
 import { CustomerModule } from './modules/customer/customer.module';
 import { ProductModule } from "./modules/product/product.module";
+import { TransactionModule } from './modules/transaction/transaction.module';
 import { DatabaseModule } from './database/database.module';
 import { SharedModule } from './shared/shared.module';
 import { AuthMiddleware } from './auth/middleware/auth.middleware';
@@ -46,6 +47,7 @@ import configuration from './config/configuration';
     FileModule,
     CustomerModule,
     ProductModule,
+    TransactionModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/transaction/dto/create-transaction.dto.ts
+++ b/src/modules/transaction/dto/create-transaction.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
+import { TransactionType, TransactionStatus, PaymentMethod } from '../entities/transaction.entity';
+
+export class CreateTransactionDto {
+  @ApiProperty({ description: '客户ID' })
+  @IsString()
+  customerId: string;
+
+  @ApiProperty({ description: '产品ID' })
+  @IsString()
+  productId: string;
+
+  @ApiProperty({ description: '交易类型', enum: TransactionType })
+  @IsEnum(TransactionType)
+  transactionType: TransactionType;
+
+  @ApiProperty({ description: '数量' })
+  @IsNumber()
+  @Min(0)
+  quantity: number;
+
+  @ApiProperty({ description: '单价' })
+  @IsNumber()
+  @Min(0)
+  unitPrice: number;
+
+  @ApiProperty({ description: '总金额', required: false })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  totalAmount?: number;
+
+  @ApiProperty({ description: '交易状态', enum: TransactionStatus, required: false })
+  @IsEnum(TransactionStatus)
+  @IsOptional()
+  transactionStatus?: TransactionStatus = TransactionStatus.PENDING;
+
+  @ApiProperty({ description: '支付方式', enum: PaymentMethod })
+  @IsEnum(PaymentMethod)
+  paymentMethod: PaymentMethod;
+
+  @ApiProperty({ description: '预期到期日期', required: false })
+  @IsString()
+  @IsOptional()
+  expectedMaturityDate?: string;
+
+  @ApiProperty({ description: '实际收益率', required: false })
+  @IsNumber()
+  @IsOptional()
+  actualReturnRate?: number;
+
+  @ApiProperty({ description: '备注信息', required: false })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+
+  @ApiProperty({ description: '完成时间', required: false })
+  @IsString()
+  @IsOptional()
+  completedAt?: string;
+}

--- a/src/modules/transaction/dto/import-result.dto.ts
+++ b/src/modules/transaction/dto/import-result.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ImportErrorDetail {
+  @ApiProperty({ description: '行号', example: 2 })
+  row: number;
+
+  @ApiProperty({ description: '错误信息', example: '数据格式错误' })
+  error: string;
+
+  @ApiProperty({ description: '行数据' })
+  data: any;
+}
+
+export class ImportResultDto {
+  @ApiProperty({ description: '导入成功数量' })
+  successCount: number;
+
+  @ApiProperty({ description: '导入失败数量' })
+  failureCount: number;
+
+  @ApiProperty({ description: '跳过数量' })
+  skippedCount: number;
+
+  @ApiProperty({ description: '总数量' })
+  totalCount: number;
+
+  @ApiProperty({ description: '错误列表', type: [ImportErrorDetail] })
+  errors: ImportErrorDetail[];
+
+  @ApiProperty({ description: '结果消息' })
+  message: string;
+}

--- a/src/modules/transaction/dto/query-transaction.dto.ts
+++ b/src/modules/transaction/dto/query-transaction.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsEnum, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { TransactionStatus } from '../entities/transaction.entity';
+
+export class QueryTransactionDto {
+  @ApiProperty({ description: '页码', required: false, example: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ description: '每页数量', required: false, example: 10, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @ApiProperty({ description: '客户ID筛选', required: false })
+  @IsOptional()
+  @IsString()
+  customerId?: string;
+
+  @ApiProperty({ description: '产品ID筛选', required: false })
+  @IsOptional()
+  @IsString()
+  productId?: string;
+
+  @ApiProperty({ description: '交易状态筛选', enum: TransactionStatus, required: false })
+  @IsOptional()
+  @IsEnum(TransactionStatus)
+  transactionStatus?: TransactionStatus;
+
+  @ApiProperty({ description: '排序字段', required: false, enum: ['createdAt', 'updatedAt'] })
+  @IsOptional()
+  @IsString()
+  sortBy?: string = 'createdAt';
+
+  @ApiProperty({ description: '排序方式', required: false, enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsEnum(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}
+
+export class TransactionListResponse {
+  @ApiProperty({ description: '记录列表', type: 'array' })
+  data: any[];
+
+  @ApiProperty({ description: '总数' })
+  total: number;
+
+  @ApiProperty({ description: '当前页码' })
+  page: number;
+
+  @ApiProperty({ description: '每页数量' })
+  limit: number;
+
+  @ApiProperty({ description: '总页数' })
+  totalPages: number;
+}

--- a/src/modules/transaction/dto/update-transaction.dto.ts
+++ b/src/modules/transaction/dto/update-transaction.dto.ts
@@ -1,0 +1,11 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { CreateTransactionDto } from './create-transaction.dto';
+
+export class UpdateTransactionDto extends PartialType(CreateTransactionDto) {
+  @ApiProperty({ description: '交易ID', required: false })
+  @IsString()
+  @IsOptional()
+  transactionId?: string;
+}

--- a/src/modules/transaction/entities/transaction.entity.ts
+++ b/src/modules/transaction/entities/transaction.entity.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum TransactionType {
+  PURCHASE = 'purchase',
+  REDEEM = 'redeem',
+}
+
+export enum TransactionStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  COMPLETED = 'completed',
+  CANCELLED = 'cancelled',
+}
+
+export enum PaymentMethod {
+  BANK_TRANSFER = 'bank_transfer',
+  CARD = 'card',
+  OTHER = 'other',
+}
+
+export class Transaction {
+  @ApiProperty({ description: '交易ID' })
+  transactionId: string;
+
+  @ApiProperty({ description: '客户ID' })
+  customerId: string;
+
+  @ApiProperty({ description: '产品ID' })
+  productId: string;
+
+  @ApiProperty({ description: '交易类型', enum: TransactionType })
+  transactionType: TransactionType;
+
+  @ApiProperty({ description: '数量' })
+  quantity: number;
+
+  @ApiProperty({ description: '单价' })
+  unitPrice: number;
+
+  @ApiProperty({ description: '总金额' })
+  totalAmount: number;
+
+  @ApiProperty({ description: '交易状态', enum: TransactionStatus })
+  transactionStatus: TransactionStatus;
+
+  @ApiProperty({ description: '支付方式', enum: PaymentMethod })
+  paymentMethod: PaymentMethod;
+
+  @ApiProperty({ description: '预期到期日期', required: false })
+  expectedMaturityDate?: string;
+
+  @ApiProperty({ description: '实际收益率', required: false })
+  actualReturnRate?: number;
+
+  @ApiProperty({ description: '备注信息', required: false })
+  notes?: string;
+
+  @ApiProperty({ description: '创建时间' })
+  createdAt: string;
+
+  @ApiProperty({ description: '更新时间' })
+  updatedAt: string;
+
+  @ApiProperty({ description: '完成时间', required: false })
+  completedAt?: string;
+}

--- a/src/modules/transaction/transaction.controller.ts
+++ b/src/modules/transaction/transaction.controller.ts
@@ -1,0 +1,107 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Put,
+  Param,
+  Delete,
+  Query,
+  Res,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Response } from 'express';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiConsumes,
+} from '@nestjs/swagger';
+
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles, Role } from '../../common/decorators/roles.decorator';
+
+import { TransactionService } from './transaction.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { QueryTransactionDto, TransactionListResponse } from './dto/query-transaction.dto';
+import { ImportResultDto } from './dto/import-result.dto';
+import { Transaction } from './entities/transaction.entity';
+
+@ApiTags('Transactions')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(RolesGuard)
+@Controller('transactions')
+export class TransactionController {
+  constructor(private readonly service: TransactionService) {}
+
+  @Post()
+  @Roles(Role.ADMIN, Role.USER)
+  @ApiOperation({ summary: '创建交易记录' })
+  create(@Body() dto: CreateTransactionDto): Promise<Transaction> {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  @Roles(Role.ADMIN, Role.USER)
+  @ApiOperation({ summary: '获取交易记录列表' })
+  findAll(@Query() query: QueryTransactionDto): Promise<TransactionListResponse> {
+    return this.service.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(Role.ADMIN, Role.USER)
+  @ApiOperation({ summary: '获取交易记录详情' })
+  @ApiParam({ name: 'id', description: '交易ID' })
+  findOne(@Param('id') id: string): Promise<Transaction> {
+    return this.service.findOne(id);
+  }
+
+  @Put(':id')
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: '更新交易记录' })
+  @ApiParam({ name: 'id', description: '交易ID' })
+  update(@Param('id') id: string, @Body() dto: UpdateTransactionDto): Promise<Transaction> {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: '删除交易记录' })
+  @ApiParam({ name: 'id', description: '交易ID' })
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+
+  @Get('export')
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: '导出交易记录为Excel' })
+  async export(@Res() res: Response) {
+    const items = await this.service.getAllForExport();
+    const buf = await this.service.generateExcelBuffer(items);
+    const filename = `transactions_${new Date().toISOString().split('T')[0]}.xlsx`;
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Content-Length', buf.length);
+    res.send(buf);
+  }
+
+  @Post('import')
+  @Roles(Role.ADMIN)
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiOperation({ summary: '从Excel导入交易记录' })
+  async import(@UploadedFile() file: Express.Multer.File): Promise<ImportResultDto> {
+    if (!file) throw new BadRequestException('请选择要上传的Excel文件');
+    return this.service.importFromExcel(file);
+  }
+}

--- a/src/modules/transaction/transaction.module.ts
+++ b/src/modules/transaction/transaction.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { TransactionService } from './transaction.service';
+import { TransactionController } from './transaction.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [TransactionService],
+  controllers: [TransactionController],
+  exports: [TransactionService],
+})
+export class TransactionModule {}

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, NotFoundException, BadRequestException, Logger, UnsupportedMediaTypeException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { v4 as uuidv4 } from 'uuid';
+import * as Excel from 'exceljs';
+
+import { DynamodbService } from '../../database/dynamodb.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { QueryTransactionDto, TransactionListResponse } from './dto/query-transaction.dto';
+import { Transaction, TransactionStatus, TransactionType, PaymentMethod } from './entities/transaction.entity';
+import { ImportResultDto, ImportErrorDetail } from './dto/import-result.dto';
+
+@Injectable()
+export class TransactionService {
+  private readonly logger = new Logger(TransactionService.name);
+  private readonly tableName: string;
+
+  constructor(
+    private readonly dynamodbService: DynamodbService,
+    private readonly configService: ConfigService,
+  ) {
+    this.tableName = this.configService.get<string>('database.tables.customerProductTransactions');
+  }
+
+  async create(dto: CreateTransactionDto): Promise<Transaction> {
+    const now = new Date().toISOString();
+    const transactionId = `txn_${uuidv4()}`;
+
+    const item: Transaction = {
+      transactionId,
+      ...dto,
+      totalAmount: dto.totalAmount ?? dto.unitPrice * dto.quantity,
+      transactionStatus: dto.transactionStatus || TransactionStatus.PENDING,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.dynamodbService.put(this.tableName, item);
+    return item;
+  }
+
+  async findAll(query: QueryTransactionDto): Promise<TransactionListResponse> {
+    const items = await this.dynamodbService.scan(this.tableName);
+
+    let filtered = items;
+    if (query.customerId) {
+      filtered = filtered.filter((i) => i.customerId === query.customerId);
+    }
+    if (query.productId) {
+      filtered = filtered.filter((i) => i.productId === query.productId);
+    }
+    if (query.transactionStatus) {
+      filtered = filtered.filter((i) => i.transactionStatus === query.transactionStatus);
+    }
+
+    filtered.sort((a, b) => {
+      const aVal = a[query.sortBy] || '';
+      const bVal = b[query.sortBy] || '';
+      if (query.sortOrder === 'asc') return String(aVal).localeCompare(String(bVal));
+      return String(bVal).localeCompare(String(aVal));
+    });
+
+    const total = filtered.length;
+    const totalPages = Math.ceil(total / query.limit);
+    const start = (query.page - 1) * query.limit;
+    const end = start + query.limit;
+    const data = filtered.slice(start, end);
+
+    return { data, total, page: query.page, limit: query.limit, totalPages };
+  }
+
+  async findOne(transactionId: string): Promise<Transaction> {
+    const item = await this.dynamodbService.get(this.tableName, { transactionId });
+    if (!item) throw new NotFoundException('记录不存在');
+    return item;
+  }
+
+  async update(transactionId: string, dto: UpdateTransactionDto): Promise<Transaction> {
+    await this.findOne(transactionId);
+
+    if (dto.transactionId && dto.transactionId !== transactionId) {
+      throw new BadRequestException('交易ID与参数不一致');
+    }
+
+    let updateExpression = 'SET #updatedAt = :updatedAt';
+    const names: Record<string, string> = { '#updatedAt': 'updatedAt' };
+    const values: Record<string, any> = { ':updatedAt': new Date().toISOString() };
+
+    Object.keys(dto).forEach((key, i) => {
+      const attr = `#attr${i}`;
+      const val = `:val${i}`;
+      updateExpression += `, ${attr} = ${val}`;
+      names[attr] = key;
+      values[val] = (dto as any)[key];
+    });
+
+    const updated = await this.dynamodbService.update(
+      this.tableName,
+      { transactionId },
+      updateExpression,
+      values,
+      names,
+    );
+
+    return updated;
+  }
+
+  async remove(transactionId: string): Promise<{ message: string }> {
+    await this.findOne(transactionId);
+    await this.dynamodbService.delete(this.tableName, { transactionId });
+    return { message: '删除成功' };
+  }
+
+  async getAllForExport(): Promise<Transaction[]> {
+    const items = await this.dynamodbService.scan(this.tableName);
+    items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    return items;
+  }
+
+  async generateExcelBuffer(transactions: Transaction[]): Promise<Buffer> {
+    const workbook = new Excel.Workbook();
+    const sheet = workbook.addWorksheet('交易记录');
+
+    sheet.columns = [
+      { header: '交易ID', key: 'transactionId', width: 20 },
+      { header: '客户ID', key: 'customerId', width: 20 },
+      { header: '产品ID', key: 'productId', width: 20 },
+      { header: '交易类型', key: 'transactionType', width: 12 },
+      { header: '数量', key: 'quantity', width: 10 },
+      { header: '单价', key: 'unitPrice', width: 10 },
+      { header: '总金额', key: 'totalAmount', width: 15 },
+      { header: '支付方式', key: 'paymentMethod', width: 15 },
+      { header: '交易状态', key: 'transactionStatus', width: 15 },
+      { header: '预期到期日期', key: 'expectedMaturityDate', width: 15 },
+      { header: '实际收益率', key: 'actualReturnRate', width: 12 },
+      { header: '备注', key: 'notes', width: 20 },
+      { header: '创建时间', key: 'createdAt', width: 20 },
+      { header: '更新时间', key: 'updatedAt', width: 20 },
+      { header: '完成时间', key: 'completedAt', width: 20 },
+    ];
+
+    transactions.forEach((t) => sheet.addRow(t));
+
+    return workbook.xlsx.writeBuffer();
+  }
+
+  async importFromExcel(file: Express.Multer.File): Promise<ImportResultDto> {
+    if (!file.originalname.endsWith('.xlsx')) {
+      throw new UnsupportedMediaTypeException('仅支持xlsx格式');
+    }
+
+    const workbook = new Excel.Workbook();
+    await workbook.xlsx.load(file.buffer);
+    const worksheet = workbook.worksheets[0];
+
+    const rows: any[] = [];
+    worksheet.eachRow((row, rowNumber) => {
+      if (rowNumber === 1) return;
+      const data = {
+        customerId: row.getCell(1).text.trim(),
+        productId: row.getCell(2).text.trim(),
+        transactionType: row.getCell(3).text.trim() as TransactionType,
+        quantity: Number(row.getCell(4).value),
+        unitPrice: Number(row.getCell(5).value),
+        totalAmount: Number(row.getCell(6).value),
+        paymentMethod: row.getCell(7).text.trim() as PaymentMethod,
+        transactionStatus: (row.getCell(8).text.trim() as TransactionStatus) || TransactionStatus.PENDING,
+        expectedMaturityDate: row.getCell(9).text.trim(),
+        actualReturnRate: row.getCell(10).value !== null ? Number(row.getCell(10).value) : undefined,
+        notes: row.getCell(11).text.trim(),
+      } as any;
+      rows.push({ data, rowNumber });
+    });
+
+    let successCount = 0;
+    const errors: ImportErrorDetail[] = [];
+
+    for (const item of rows) {
+      try {
+        await this.create(item.data);
+        successCount++;
+      } catch (e) {
+        errors.push({ row: item.rowNumber, error: e.message, data: item.data });
+      }
+    }
+
+    const result: ImportResultDto = {
+      successCount,
+      failureCount: errors.length,
+      skippedCount: 0,
+      totalCount: rows.length,
+      errors,
+      message: `导入完成：成功 ${successCount} 条，失败 ${errors.length} 条`,
+    };
+
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- implement transaction module for customer product transactions
- support CRUD and Excel import/export
- wire up TransactionModule in AppModule

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68776b3dc0e483269bd5f36991fa83dc