### PR TITLE
Add customer login accounts

### DIFF
--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -4,6 +4,7 @@ export enum Role {
   USER = 'user',
   ADMIN = 'admin',
   MODERATOR = 'moderator',
+  CUSTOMER = 'customer',
 }
 
 export const ROLES_KEY = 'roles';

--- a/src/modules/customer/customer.module.ts
+++ b/src/modules/customer/customer.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { CustomerService } from './customer.service';
 import { CustomerController } from './customer.controller';
 import { DatabaseModule } from '../../database/database.module';
+import { AuthModule } from '../../auth/auth.module';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, AuthModule],
   controllers: [CustomerController],
   providers: [CustomerService],
   exports: [CustomerService],

--- a/src/modules/customer/dto/create-customer.dto.ts
+++ b/src/modules/customer/dto/create-customer.dto.ts
@@ -26,6 +26,22 @@ export class CreateCustomerDto {
   @IsNotEmpty({ message: '邮箱地址不能为空' })
   email: string;
 
+  @ApiProperty({ description: '登录账号', example: 'customer01' })
+  @IsString({ message: '登录账号必须是字符串' })
+  @IsNotEmpty({ message: '登录账号不能为空' })
+  @MinLength(3, { message: '登录账号至少需要3个字符' })
+  @MaxLength(30, { message: '登录账号不能超过30个字符' })
+  username: string;
+
+  @ApiProperty({
+    description: '登录密码',
+    example: 'Password123!',
+  })
+  @IsString({ message: '登录密码必须是字符串' })
+  @IsNotEmpty({ message: '登录密码不能为空' })
+  @MinLength(8, { message: '登录密码至少需要8个字符' })
+  password: string;
+
   @ApiProperty({
     description: '手机号码',
     example: '+86 138 0013 8000',


### PR DESCRIPTION
## Summary
- add new `customer` role
- allow providing username/password when creating customers
- register a customer account in Cognito and DynamoDB when customer is created

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6877767e4b988326b3673ddda9afac07