### PR TITLE
Add user change-password endpoint

### DIFF
--- a/src/modules/user/dto/change-password.dto.ts
+++ b/src/modules/user/dto/change-password.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @ApiProperty({ description: 'Current password', example: 'OldPassword123!' })
+  @IsString()
+  @MinLength(8)
+  currentPassword: string;
+
+  @ApiProperty({ description: 'New password', example: 'NewPassword123!' })
+  @IsString()
+  @MinLength(8)
+  newPassword: string;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -17,6 +17,7 @@ import {
 
 import { UserService } from './user.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { Roles, Role } from '../../common/decorators/roles.decorator';
@@ -63,6 +64,17 @@ export class UserController {
     @Body() updateUserDto: UpdateUserDto,
   ) {
     return this.userService.update(userId, updateUserDto);
+  }
+
+  @Patch('me/password')
+  @ApiOperation({ summary: 'Change current user password' })
+  @ApiResponse({ status: 200, description: 'Password updated successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid current password or email not verified' })
+  changePassword(
+    @CurrentUser('userId') userId: string,
+    @Body() dto: ChangePasswordDto,
+  ) {
+    return this.userService.changePassword(userId, dto);
   }
 
   @Patch(':id')

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,10 +1,20 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { DynamodbService } from '../../database/dynamodb.service';
+import { CognitoService } from '../../shared/services/cognito.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import * as bcrypt from 'bcryptjs';
 
 @Injectable()
 export class UserService {
-  constructor(private dynamodbService: DynamodbService) {}
+  constructor(
+    private dynamodbService: DynamodbService,
+    private cognitoService: CognitoService,
+  ) {}
 
   async findAll() {
     return await this.dynamodbService.scan('users');
@@ -69,6 +79,40 @@ export class UserService {
 
     const { password, ...userWithoutPassword } = updatedUser;
     return userWithoutPassword;
+  }
+
+  async changePassword(userId: string, dto: ChangePasswordDto) {
+    const user = await this.dynamodbService.get('users', { userId });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (!user.email || !user.emailVerified) {
+      throw new BadRequestException('Email not verified');
+    }
+
+    const match = await bcrypt.compare(dto.currentPassword, user.password);
+    if (!match) {
+      throw new BadRequestException('Invalid current password');
+    }
+
+    const hashed = await bcrypt.hash(dto.newPassword, 10);
+
+    await this.cognitoService.setUserPassword(userId, dto.newPassword, true);
+
+    await this.dynamodbService.update(
+      'users',
+      { userId },
+      'SET #password = :password, #updatedAt = :updatedAt',
+      {
+        ':password': hashed,
+        ':updatedAt': new Date().toISOString(),
+      },
+      { '#password': 'password', '#updatedAt': 'updatedAt' },
+    );
+
+    return { message: 'Password updated successfully' };
   }
 
   async remove(userId: string) {


### PR DESCRIPTION
## Summary
- allow logged-in users to change password
- require a verified email before allowing password changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779017b6fc8326a0bbf2cc6b1192cb