### PR TITLE
Add super admin and sub-admin features

### DIFF
--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -3,6 +3,7 @@ import { SetMetadata } from '@nestjs/common';
 export enum Role {
   USER = 'user',
   ADMIN = 'admin',
+  SUPER_ADMIN = 'super_admin',
   MODERATOR = 'moderator',
   CUSTOMER = 'customer',
 }

--- a/src/modules/customer/customer.controller.ts
+++ b/src/modules/customer/customer.controller.ts
@@ -46,7 +46,7 @@ export class CustomerController {
   constructor(private readonly customerService: CustomerService) {}
 
   @Post()
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '创建新客户' })
   @ApiResponse({
     status: HttpStatus.CREATED,
@@ -71,7 +71,7 @@ export class CustomerController {
   }
 
   @Get()
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '获取客户列表' })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -92,7 +92,7 @@ export class CustomerController {
   }
 
   @Get('search/email/:email')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '根据邮箱查找客户' })
   @ApiParam({
     name: 'email',
@@ -118,7 +118,7 @@ export class CustomerController {
   }
 
   @Get('search/phone/:phone')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '根据手机号查找客户' })
   @ApiParam({
     name: 'phone',
@@ -144,7 +144,7 @@ export class CustomerController {
   }
 
   @Get(':id')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '根据ID获取客户详情' })
   @ApiParam({
     name: 'id',
@@ -170,7 +170,7 @@ export class CustomerController {
   }
 
   @Put(':id')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '更新客户信息' })
   @ApiParam({
     name: 'id',
@@ -207,7 +207,7 @@ export class CustomerController {
   }
 
   @Delete(':id')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '删除客户' })
   @ApiParam({
     name: 'id',
@@ -236,7 +236,7 @@ export class CustomerController {
   }
 
   @Get('export')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '导出客户数据为Excel文件' })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -289,7 +289,7 @@ export class CustomerController {
   }
 
   @Post('import')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: '从Excel文件导入客户数据' })

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -94,7 +94,7 @@ export class FileController {
   @ApiResponse({ status: 200, description: 'Files retrieved successfully' })
   findAll(@CurrentUser() user: any, @Query('userId') userId?: string) {
     // Regular users can only see their own files
-    if (user.role !== 'admin') {
+    if (user.role !== 'super_admin') {
       return this.fileService.findAll(user.userId);
     }
 
@@ -120,7 +120,7 @@ export class FileController {
   @ApiResponse({ status: 403, description: 'Access denied' })
   findOne(@Param('id') id: string, @CurrentUser() user: any) {
     // Regular users can only access their own files
-    const userId = user.role === 'admin' ? undefined : user.userId;
+    const userId = user.role === 'super_admin' ? undefined : user.userId;
     return this.fileService.findOne(id, userId);
   }
 
@@ -144,7 +144,7 @@ export class FileController {
     @Query('expiresIn') expiresIn?: number,
   ) {
     // Regular users can only access their own files
-    const userId = user.role === 'admin' ? undefined : user.userId;
+    const userId = user.role === 'super_admin' ? undefined : user.userId;
     return this.fileService.getFileUrl(id, userId, expiresIn);
   }
 

--- a/src/modules/product/product.controller.ts
+++ b/src/modules/product/product.controller.ts
@@ -42,14 +42,14 @@ export class ProductController {
   constructor(private readonly productService: ProductService) {}
 
   @Post()
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '创建产品' })
   create(@Body() dto: CreateProductDto): Promise<Product> {
     return this.productService.create(dto);
   }
 
   @Get()
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '获取产品列表' })
   @ApiQuery({ name: 'page', required: false })
   findAll(@Query() query: QueryProductDto): Promise<ProductListResponse> {
@@ -57,7 +57,7 @@ export class ProductController {
   }
 
   @Get(':id')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '获取产品详情' })
   @ApiParam({ name: 'id', description: '产品ID' })
   findOne(@Param('id') id: string): Promise<Product> {
@@ -65,7 +65,7 @@ export class ProductController {
   }
 
   @Put(':id')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '更新产品' })
   @ApiParam({ name: 'id', description: '产品ID' })
   update(@Param('id') id: string, @Body() dto: UpdateProductDto): Promise<Product> {
@@ -73,7 +73,7 @@ export class ProductController {
   }
 
   @Delete(':id')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '删除产品' })
   @ApiParam({ name: 'id', description: '产品ID' })
   remove(@Param('id') id: string) {
@@ -81,7 +81,7 @@ export class ProductController {
   }
 
   @Get('export')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '导出产品数据为Excel' })
   async export(@Res() res: Response) {
     const products = await this.productService.getAllForExport();
@@ -97,7 +97,7 @@ export class ProductController {
   }
 
   @Post('import')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: '从Excel导入产品数据' })

--- a/src/modules/trade/trade.controller.ts
+++ b/src/modules/trade/trade.controller.ts
@@ -51,7 +51,7 @@ export class TradeController {
   @ApiResponse({ status: 200, description: 'Trades retrieved successfully' })
   findAll(@CurrentUser() user: any, @Query('userId') userId?: string) {
     // Regular users can only see their own trades
-    if (user.role !== 'admin') {
+    if (user.role !== 'super_admin') {
       return this.tradeService.findAll(user.userId);
     }
 
@@ -77,7 +77,7 @@ export class TradeController {
   @ApiResponse({ status: 403, description: 'Access denied' })
   findOne(@Param('id') id: string, @CurrentUser() user: any) {
     // Regular users can only access their own trades
-    const userId = user.role === 'admin' ? undefined : user.userId;
+    const userId = user.role === 'super_admin' ? undefined : user.userId;
     return this.tradeService.findOne(id, userId);
   }
 

--- a/src/modules/transaction/transaction.controller.ts
+++ b/src/modules/transaction/transaction.controller.ts
@@ -42,21 +42,21 @@ export class TransactionController {
   constructor(private readonly service: TransactionService) {}
 
   @Post()
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '创建交易记录' })
   create(@Body() dto: CreateTransactionDto): Promise<Transaction> {
     return this.service.create(dto);
   }
 
   @Get()
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '获取交易记录列表' })
   findAll(@Query() query: QueryTransactionDto): Promise<TransactionListResponse> {
     return this.service.findAll(query);
   }
 
   @Get(':id')
-  @Roles(Role.ADMIN, Role.USER)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN, Role.USER)
   @ApiOperation({ summary: '获取交易记录详情' })
   @ApiParam({ name: 'id', description: '交易ID' })
   findOne(@Param('id') id: string): Promise<Transaction> {
@@ -64,7 +64,7 @@ export class TransactionController {
   }
 
   @Put(':id')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '更新交易记录' })
   @ApiParam({ name: 'id', description: '交易ID' })
   update(@Param('id') id: string, @Body() dto: UpdateTransactionDto): Promise<Transaction> {
@@ -72,7 +72,7 @@ export class TransactionController {
   }
 
   @Delete(':id')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '删除交易记录' })
   @ApiParam({ name: 'id', description: '交易ID' })
   remove(@Param('id') id: string) {
@@ -80,7 +80,7 @@ export class TransactionController {
   }
 
   @Get('export')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @ApiOperation({ summary: '导出交易记录为Excel' })
   async export(@Res() res: Response) {
     const items = await this.service.getAllForExport();
@@ -96,7 +96,7 @@ export class TransactionController {
   }
 
   @Post('import')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN, Role.ADMIN)
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: '从Excel导入交易记录' })

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -29,7 +29,7 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get()
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN)
   @UseGuards(RolesGuard)
   @ApiOperation({ summary: 'Get all users (Admin only)' })
   @ApiResponse({ status: 200, description: 'Users retrieved successfully' })
@@ -77,8 +77,28 @@ export class UserController {
     return this.userService.changePassword(userId, dto);
   }
 
+  @Patch('make-super-admin')
+  @ApiOperation({ summary: 'Promote current user to super admin' })
+  @ApiResponse({ status: 200, description: 'User promoted to super admin' })
+  @ApiResponse({ status: 400, description: 'Super admin already exists or email not verified' })
+  makeSuperAdmin(@CurrentUser('userId') userId: string) {
+    return this.userService.makeSuperAdmin(userId);
+  }
+
+  @Patch(':id/make-admin')
+  @Roles(Role.SUPER_ADMIN)
+  @UseGuards(RolesGuard)
+  @ApiOperation({ summary: 'Set user as admin (Super admin only)' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'User promoted to admin' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  setAdmin(@Param('id') id: string) {
+    return this.userService.setAdmin(id);
+  }
+
   @Patch(':id')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN)
   @UseGuards(RolesGuard)
   @ApiOperation({ summary: 'Update user by ID (Admin only)' })
   @ApiParam({ name: 'id', description: 'User ID' })
@@ -90,7 +110,7 @@ export class UserController {
   }
 
   @Delete(':id')
-  @Roles(Role.ADMIN)
+  @Roles(Role.SUPER_ADMIN)
   @UseGuards(RolesGuard)
   @ApiOperation({ summary: 'Delete user by ID (Admin only)' })
   @ApiParam({ name: 'id', description: 'User ID' })


### PR DESCRIPTION
## Summary
- support a `SUPER_ADMIN` role
- allow promoting a verified user to super admin
- allow super admin to set other users as admins
- update role checks in controllers

## Testing
- `npm run test` *(fails: jest not found)*
- `npm install` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6877942603548326910a17643ca420cf