### PR TITLE
Fix customer import DTO and Excel buffer

### DIFF
--- a/src/modules/customer/customer.service.ts
+++ b/src/modules/customer/customer.service.ts
@@ -67,14 +67,16 @@ export class CustomerService {
     try {
       await this.dynamodbService.put(this.tableName, customer);
 
-      await this.authService.registerCustomerAccount(
-        username,
-        password,
-        customer.email,
-        customer.firstName,
-        customer.lastName,
-        customerId,
-      );
+      if (username && password) {
+        await this.authService.registerCustomerAccount(
+          username,
+          password,
+          customer.email,
+          customer.firstName,
+          customer.lastName,
+          customerId,
+        );
+      }
 
       this.logger.log(`Customer created successfully with ID: ${customerId}`);
       return customer;

--- a/src/modules/customer/dto/create-customer.dto.ts
+++ b/src/modules/customer/dto/create-customer.dto.ts
@@ -26,21 +26,22 @@ export class CreateCustomerDto {
   @IsNotEmpty({ message: '邮箱地址不能为空' })
   email: string;
 
-  @ApiProperty({ description: '登录账号', example: 'customer01' })
+  @ApiProperty({ description: '登录账号', example: 'customer01', required: false })
   @IsString({ message: '登录账号必须是字符串' })
-  @IsNotEmpty({ message: '登录账号不能为空' })
+  @IsOptional()
   @MinLength(3, { message: '登录账号至少需要3个字符' })
   @MaxLength(30, { message: '登录账号不能超过30个字符' })
-  username: string;
+  username?: string;
 
   @ApiProperty({
     description: '登录密码',
     example: 'Password123!',
+    required: false,
   })
   @IsString({ message: '登录密码必须是字符串' })
-  @IsNotEmpty({ message: '登录密码不能为空' })
+  @IsOptional()
   @MinLength(8, { message: '登录密码至少需要8个字符' })
-  password: string;
+  password?: string;
 
   @ApiProperty({
     description: '手机号码',

--- a/src/modules/product/product.service.ts
+++ b/src/modules/product/product.service.ts
@@ -156,7 +156,8 @@ export class ProductService {
 
     products.forEach((p) => sheet.addRow(p));
 
-    return workbook.xlsx.writeBuffer();
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
   }
 
   async importFromExcel(file: Express.Multer.File): Promise<ImportResultDto> {

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -170,7 +170,8 @@ export class TransactionService {
 
     transactions.forEach((t) => sheet.addRow(t));
 
-    return workbook.xlsx.writeBuffer();
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
   }
 
   async importFromExcel(file: Express.Multer.File): Promise<ImportResultDto> {


### PR DESCRIPTION
## Summary
- make username and password optional in `CreateCustomerDto`
- register customer account only when credentials are provided
- return Node buffers for product and transaction Excel export

## Testing
- `yarn start:dev`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6877b4a363908326902341f90959601e