### PR TITLE
Add statistics endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { FileModule } from './modules/file/file.module';
 import { CustomerModule } from './modules/customer/customer.module';
 import { ProductModule } from './modules/product/product.module';
 import { TransactionModule } from './modules/transaction/transaction.module';
+import { StatsModule } from './modules/stats/stats.module';
 import { DatabaseModule } from './database/database.module';
 import { SharedModule } from './shared/shared.module';
 import { AuthMiddleware } from './auth/middleware/auth.middleware';
@@ -46,6 +47,7 @@ import configuration from './config/configuration';
     CustomerModule,
     ProductModule,
     TransactionModule,
+    StatsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/stats/stats.controller.ts
+++ b/src/modules/stats/stats.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Roles, Role } from '../../common/decorators/roles.decorator';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { StatsService, SummaryStats, HistoryEntry } from './stats.service';
+
+@ApiTags('Statistics')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(RolesGuard)
+@Controller('stats')
+export class StatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get('summary')
+  @Roles(Role.ADMIN, Role.SUPER_ADMIN)
+  @ApiOperation({ summary: '获取统计汇总' })
+  async getSummary(): Promise<SummaryStats> {
+    return this.statsService.getSummary();
+  }
+
+  @Get('history')
+  @Roles(Role.ADMIN, Role.SUPER_ADMIN)
+  @ApiOperation({ summary: '按时间维度获取历史统计' })
+  @ApiQuery({
+    name: 'granularity',
+    required: false,
+    enum: ['day', 'month'],
+    description: '时间粒度，默认按月',
+  })
+  async getHistory(
+    @Query('granularity') granularity: 'day' | 'month' = 'month',
+  ): Promise<HistoryEntry[]> {
+    return this.statsService.getHistory(granularity);
+  }
+}

--- a/src/modules/stats/stats.module.ts
+++ b/src/modules/stats/stats.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { StatsService } from './stats.service';
+import { StatsController } from './stats.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [StatsService],
+  controllers: [StatsController],
+  exports: [StatsService],
+})
+export class StatsModule {}

--- a/src/modules/stats/stats.service.ts
+++ b/src/modules/stats/stats.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DynamodbService } from '../../database/dynamodb.service';
+import { TransactionStatus } from '../transaction/entities/transaction.entity';
+
+export interface SummaryStats {
+  totalCustomers: number;
+  activeCustomers: number;
+  customersWithoutTransactions: number;
+  historicalSales: number;
+  ongoingSales: number;
+}
+
+export interface HistoryEntry extends SummaryStats {
+  date: string;
+}
+
+@Injectable()
+export class StatsService {
+  private readonly logger = new Logger(StatsService.name);
+  private readonly customersTable: string;
+  private readonly transactionsTable: string;
+
+  constructor(
+    private readonly dynamodbService: DynamodbService,
+    private readonly configService: ConfigService,
+  ) {
+    this.customersTable = this.configService.get<string>('database.tables.customers');
+    this.transactionsTable = this.configService.get<string>('database.tables.customerProductTransactions');
+  }
+
+  async getSummary(): Promise<SummaryStats> {
+    const customers = await this.dynamodbService.scan(this.customersTable);
+    const transactions = await this.dynamodbService.scan(this.transactionsTable);
+
+    const activeStatuses = [TransactionStatus.PENDING, TransactionStatus.CONFIRMED];
+
+    const totalCustomers = customers.length;
+    const customersWithTransactions = new Set(transactions.map((t) => t.customerId));
+    const activeCustomerIds = new Set(
+      transactions
+        .filter((t) => activeStatuses.includes(t.transactionStatus))
+        .map((t) => t.customerId),
+    );
+
+    const activeCustomers = customers.filter((c) => activeCustomerIds.has(c.customerId)).length;
+    const customersWithoutTransactions = customers.filter(
+      (c) => !customersWithTransactions.has(c.customerId),
+    ).length;
+
+    const historicalSales = transactions
+      .filter((t) => t.transactionStatus === TransactionStatus.COMPLETED)
+      .reduce((sum, t) => sum + (t.totalAmount || 0), 0);
+
+    const ongoingSales = transactions
+      .filter((t) => activeStatuses.includes(t.transactionStatus))
+      .reduce((sum, t) => sum + (t.totalAmount || 0), 0);
+
+    return {
+      totalCustomers,
+      activeCustomers,
+      customersWithoutTransactions,
+      historicalSales,
+      ongoingSales,
+    };
+  }
+
+  private formatDate(dateStr: string, granularity: 'day' | 'month'): string {
+    const date = new Date(dateStr);
+    if (granularity === 'day') {
+      return date.toISOString().slice(0, 10);
+    }
+    return date.toISOString().slice(0, 7);
+  }
+
+  async getHistory(granularity: 'day' | 'month' = 'month'): Promise<HistoryEntry[]> {
+    const customers = await this.dynamodbService.scan(this.customersTable);
+    const transactions = await this.dynamodbService.scan(this.transactionsTable);
+
+    const activeStatuses = [TransactionStatus.PENDING, TransactionStatus.CONFIRMED];
+
+    const buckets: Record<string, HistoryEntry> = {};
+
+    const getBucket = (date: string): HistoryEntry => {
+      if (!buckets[date]) {
+        buckets[date] = {
+          date,
+          totalCustomers: 0,
+          activeCustomers: 0,
+          customersWithoutTransactions: 0,
+          historicalSales: 0,
+          ongoingSales: 0,
+        };
+      }
+      return buckets[date];
+    };
+
+    const transactionsByCustomer: Record<string, any[]> = {};
+    for (const t of transactions) {
+      if (!transactionsByCustomer[t.customerId]) {
+        transactionsByCustomer[t.customerId] = [];
+      }
+      transactionsByCustomer[t.customerId].push(t);
+    }
+
+    for (const customer of customers) {
+      const key = this.formatDate(customer.createdAt, granularity);
+      const bucket = getBucket(key);
+      bucket.totalCustomers += 1;
+
+      const custTxns = transactionsByCustomer[customer.customerId] || [];
+      if (custTxns.length === 0) {
+        bucket.customersWithoutTransactions += 1;
+      } else if (custTxns.some((t) => activeStatuses.includes(t.transactionStatus))) {
+        bucket.activeCustomers += 1;
+      }
+    }
+
+    for (const t of transactions) {
+      const key = this.formatDate(t.completedAt || t.createdAt, granularity);
+      const bucket = getBucket(key);
+
+      if (t.transactionStatus === TransactionStatus.COMPLETED) {
+        bucket.historicalSales += t.totalAmount || 0;
+      } else if (activeStatuses.includes(t.transactionStatus)) {
+        bucket.ongoingSales += t.totalAmount || 0;
+      }
+    }
+
+    return Object.values(buckets).sort((a, b) => a.date.localeCompare(b.date));
+  }
+}


### PR DESCRIPTION
## Summary
- add statistics module with summary and history stats
- secure statistics with admin roles

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68787077a83883268761ded8906ac87a