### PR TITLE
Fix lambda build path resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "node --test",
+    "test": "node --test test",
     "mastra:dev": "mastra dev",
     "cdk:deploy:dev": "cd infrastructure && npm run cdk deploy -- --context environment=dev",
     "cdk:deploy:prod": "cd infrastructure && npm run cdk deploy -- --context environment=prod",

--- a/scripts/build-lambda.sh
+++ b/scripts/build-lambda.sh
@@ -40,8 +40,8 @@ echo "📦 Installing production dependencies..."
 cp package.json lambda-package/
 cd lambda-package
 
-# Install only production dependencies
-npm install --only=production --no-package-lock
+# Install only production dependencies without running postinstall scripts
+HUSKY=0 npm install --only=production --no-package-lock --ignore-scripts
 
 # Remove unnecessary files to reduce package size
 echo "🗑️  Removing unnecessary files..."

--- a/webpack.lambda.config.js
+++ b/webpack.lambda.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   mode: 'production',
@@ -11,6 +12,7 @@ module.exports = {
   },
   resolve: {
     extensions: ['.ts', '.js'],
+    plugins: [new TsconfigPathsPlugin({ configFile: path.resolve(__dirname, 'tsconfig.json') })],
   },
   module: {
     rules: [


### PR DESCRIPTION
## Summary
- add tsconfig paths plugin for webpack lambda build
- skip husky during lambda packaging
- restrict `npm test` to `test` folder so Node doesn't run integration script

## Testing
- `npm run build:lambda`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bc5ae952883268b7de9ea2fd1e68a