### PR TITLE
Fix lambda build dependency conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ For support and questions:
 - Check the troubleshooting section
 - Review AWS documentation for service-specific issues
 
+## 📦 Dependency Notes
+
+This project uses AI workflows via Mastra and the `ai` SDK. To avoid version
+conflicts when deploying AWS Lambda functions, the `@openrouter/ai-sdk-provider`
+package is pinned to **`1.0.0-beta.1`**, which is compatible with `zod` v3 used
+by the `ai` library. If `npm install` fails with dependency resolution errors,
+ensure that this exact version is used.
+
 ## 🔄 Version History
 
 - **v1.0.0** - Initial release with core functionality

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.3.0",
     "@nestjs/swagger": "^7.1.17",
-    "@openrouter/ai-sdk-provider": "^1.0.0-beta.1",
+    "@openrouter/ai-sdk-provider": "1.0.0-beta.1",
     "@types/aws-lambda": "^8.10.150",
     "@types/multer": "^2.0.0",
     "@vendia/serverless-express": "^4.12.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         specifier: ^7.1.17
         version: 7.4.2(@nestjs/common@10.4.19(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.19)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)
       '@openrouter/ai-sdk-provider':
-        specifier: ^1.0.0-beta.1
+        specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1(ai@5.0.0-canary.24(zod@3.25.76))(zod@3.25.76)
       '@types/aws-lambda':
         specifier: ^8.10.150


### PR DESCRIPTION
## Summary
- pin `@openrouter/ai-sdk-provider` to `1.0.0-beta.1` to avoid zod v4 conflict
- document dependency pin in README

## Testing
- `pnpm install`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_687cea2111408326ac6223ea40d54efa