### PR TITLE
Fix start:dev by disabling webpack

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,7 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": true,
+    "webpack": false,
     "tsConfigPath": "tsconfig.build.json"
   }
 }


### PR DESCRIPTION
## Summary
- disable webpack in `nest-cli.json` so the development server uses `main.ts`

## Testing
- `node node_modules/@nestjs/cli/bin/nest.js start` *(fails due to port in use, but shows Nest application starting)*

------
https://chatgpt.com/codex/tasks/task_e_687e4e53f58083269682fd493b999f2a